### PR TITLE
feat: swap to working url when something didnt work

### DIFF
--- a/utils/URL.ts
+++ b/utils/URL.ts
@@ -1,39 +1,36 @@
+function shuffleArray(array: (string | undefined)[]) {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+  return array;
+}
+
+export function getAllUrls() {
+  const urls = [
+    process.env.NEXT_PUBLIC_API_URL_MORN || process.env.NEXT_PUBLIC_API_URL,
+    process.env.NEXT_PUBLIC_API_URL_EVEN || process.env.NEXT_PUBLIC_API_URL,
+    process.env.NEXT_PUBLIC_API_URL_NIGHT || process.env.NEXT_PUBLIC_API_URL,
+    process.env.NEXT_PUBLIC_API_URL_2 || process.env.NEXT_PUBLIC_API_URL,
+    process.env.NEXT_PUBLIC_API_URL_H || process.env.NEXT_PUBLIC_API_URL,
+  ];
+
+  return shuffleArray(urls);
+}
 
 export function getUrl() {
+  const urls = [
+    process.env.NEXT_PUBLIC_API_URL_MORN,
+    process.env.NEXT_PUBLIC_API_URL_EVEN,
+    process.env.NEXT_PUBLIC_API_URL_NIGHT,
+    process.env.NEXT_PUBLIC_API_URL_2,
+    process.env.NEXT_PUBLIC_API_URL_H,
+    process.env.NEXT_PUBLIC_API_URL,
+  ];
 
-  const rand = Math.floor(Math.random() * 4) + 1;
-  switch (rand) {
-    case 1:
-      return (
-        process.env.NEXT_PUBLIC_API_URL_MORN || process.env.NEXT_PUBLIC_API_URL
-      );
-    case 2:
-      return (
-        process.env.NEXT_PUBLIC_API_URL_EVEN || process.env.NEXT_PUBLIC_API_URL
-      );
-    case 3:
-      return (
-        process.env.NEXT_PUBLIC_API_URL_NIGHT || process.env.NEXT_PUBLIC_API_URL
-      );
-    case 4:
-      return (
-        process.env.NEXT_PUBLIC_API_URL_2 || process.env.NEXT_PUBLIC_API_URL
-      );
-    default:
-      return process.env.NEXT_PUBLIC_API_URL;
-  }
+  const rand = Math.floor(Math.random() * 5);
+
+  return urls[rand] || process.env.NEXT_PUBLIC_API_URL_H;
 }
 
 export const revalUrl = process.env.NEXT_PUBLIC_API_URL;
-
-// function hash(token: string): number {
-//     const combined = `${token}`;
-//     let hash = 0;
-//     for (let i = 0; i < combined.length; i++) {
-//         hash = (hash << 5) - hash + combined.charCodeAt(i);
-//         hash |= 0;
-//     }
-
-//     const minutes = Math.floor(Date.now() / (1000 * 60 * 5));
-//     return Math.abs((hash + minutes) % 3) + 1;
-// }

--- a/utils/URL.ts
+++ b/utils/URL.ts
@@ -6,29 +6,21 @@ function shuffleArray(array: (string | undefined)[]) {
   return array;
 }
 
-export function getAllUrls() {
-  const urls = [
-    process.env.NEXT_PUBLIC_API_URL_MORN || process.env.NEXT_PUBLIC_API_URL,
-    process.env.NEXT_PUBLIC_API_URL_EVEN || process.env.NEXT_PUBLIC_API_URL,
-    process.env.NEXT_PUBLIC_API_URL_NIGHT || process.env.NEXT_PUBLIC_API_URL,
-    process.env.NEXT_PUBLIC_API_URL_2 || process.env.NEXT_PUBLIC_API_URL,
-    process.env.NEXT_PUBLIC_API_URL_H || process.env.NEXT_PUBLIC_API_URL,
-  ];
+const urls = [
+  process.env.NEXT_PUBLIC_API_URL_MORN,
+  process.env.NEXT_PUBLIC_API_URL_EVEN,
+  process.env.NEXT_PUBLIC_API_URL_NIGHT,
+  process.env.NEXT_PUBLIC_API_URL_2,
+  process.env.NEXT_PUBLIC_API_URL_H,
+  process.env.NEXT_PUBLIC_API_URL,
+];
 
+export function getAllUrls() {
   return shuffleArray(urls);
 }
 
 export function getUrl() {
-  const urls = [
-    process.env.NEXT_PUBLIC_API_URL_MORN,
-    process.env.NEXT_PUBLIC_API_URL_EVEN,
-    process.env.NEXT_PUBLIC_API_URL_NIGHT,
-    process.env.NEXT_PUBLIC_API_URL_2,
-    process.env.NEXT_PUBLIC_API_URL_H,
-    process.env.NEXT_PUBLIC_API_URL,
-  ];
-
-  const rand = Math.floor(Math.random() * 5);
+  const rand = Math.floor(Math.random() * urls.length);
 
   return urls[rand] || process.env.NEXT_PUBLIC_API_URL_H;
 }


### PR DESCRIPTION
## What's new
- [x] Swap to the working url as a fallback
- [x] Using `get` endpoint to get all data
- [ ] Make `getCal` to get dayorder and calendar in same shot